### PR TITLE
Initial commit for C++ Kalman Filter implementation.

### DIFF
--- a/sailtrack/kalman-c/dynamic-kalman-filter.h
+++ b/sailtrack/kalman-c/dynamic-kalman-filter.h
@@ -1,0 +1,115 @@
+/* TODO - Do some testing
+ */
+
+#ifndef DYNAMIC_KALMAN_FILTER_H
+#define DYNAMIC_KALMAN_FILTER_H
+
+// YOU NEED TO ADD YOUR EIGEN LIBRARY PATH YOURSELF
+#include <Eigen/Dense> // TODO - Make this library work in PlatformIO
+
+namespace kf
+{
+
+    // Useful Aliases
+    using dMatrix = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
+    using dVector = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+
+    /** Generic implementation of a Kalman Filter using Eigen library.
+     *  Matrices have dynamic size.
+     */
+    class DynamicKalmanFilter
+    {
+    public:
+        DynamicKalmanFilter(const dMatrix &F, const dMatrix &G, const dMatrix &H,
+                            const dMatrix &Q);
+        DynamicKalmanFilter(const dMatrix &F, const dMatrix &G, const dMatrix &H,
+                            const dMatrix &Q, const dVector &x_hat_init, const dMatrix &P_init);
+
+        // Time Update
+        void predict();
+        void predict(const dVector &input_vector);
+        void predict(const dVector &input_vector, const dVector &measurement_vector);
+
+        // Measurement Update
+        void correct(const dVector &measurement_vector);
+
+        // Member access
+        const dVector &state_estimate() const { return x_hat_; }
+        const dMatrix &state_covariance_estimate() const { return P_; }
+
+        // Member update
+        void update_noise_covariance(const dMatrix &R_new) { R_ = R_new; }
+
+    private:
+        // TODO - Change to const where appropriate, eventually constexpr for fixed model if necessary
+        const dMatrix F_; // state transition
+        const dMatrix G_; // input/control
+        const dMatrix H_; // output/observation
+        const dMatrix Q_; // state noise covariance
+        dMatrix R_;       // measurment noise covariance
+        dMatrix S_;       // measure-to-state uncorrelation (?)
+        dVector x_hat_;   // state estimate
+        dMatrix P_;       // state covariance estimate
+    };
+
+    DynamicKalmanFilter::DynamicKalmanFilter(const dMatrix &F, const dMatrix &G, const dMatrix &H,
+                                             const dMatrix &Q)
+        : F_{F},
+          G_{G},
+          H_{H},
+          Q_{Q},
+          R_{dMatrix::Zero(H.rows(), H.cols())},    // NOTE: THIS ONLY WORKS IF DECLARATION OF H_ COMES BEFORE R_
+          S_{dMatrix::Zero(F.rows(), H.cols())},    // NOTE: THIS ONLY WORKS IF DECLARATION OF F_, H_ COMES BEFORE S_
+          x_hat_{dVector::Zero(F.rows())},          // NOTE: THIS ONLY WORKS IF DECLARATION OF F_ COMES BEFORE X_HAT_
+          P_{dMatrix::Identity(F.rows(), F.cols())} // NOTE: THIS ONLY WORKS IF DECLARATION OF F_ COMES BEFORE P_
+    {
+    }
+
+    DynamicKalmanFilter::DynamicKalmanFilter(const dMatrix &F, const dMatrix &G, const dMatrix &H,
+                                             const dMatrix &Q, const dVector &x_hat_init, const dMatrix &P_init)
+        : F_{F},
+          G_{G},
+          H_{H},
+          Q_{Q},
+          R_{dMatrix::Zero(H.rows(), H.cols())}, // NOTE: THIS ONLY WORKS IF DECLARATION OF H_ COMES BEFORE R_
+          S_{dMatrix::Zero(F.rows(), F.cols())}, // NOTE: THIS ONLY WORKS IF DECLARATION OF A_, H_ COMES BEFORE S_
+          x_hat_{x_hat_init},
+          P_{P_init}
+    {
+    }
+
+    void DynamicKalmanFilter::predict()
+    {
+        x_hat_ = F_ * x_hat_;               // extrapolate state
+        P_ = F_ * P_ * F_.transpose() + Q_; // extrapolate state covariance
+    }
+
+    void DynamicKalmanFilter::predict(const dVector &input_vector)
+    {
+        x_hat_ = F_ * x_hat_ + G_ * input_vector; // extrapolate state
+        P_ = F_ * P_ * F_.transpose() + Q_;       // extrapolate state covariance
+    }
+
+    void DynamicKalmanFilter::predict(const dVector &input_vector, const dVector &measurement_vector)
+    {
+        // NOTE - R is diagonal in our model, can be optimized.
+        x_hat_ = F_ * x_hat_ + G_ * input_vector + S_ * R_.ldlt().solve(measurement_vector); // extrapolate state
+        P_ = F_ * P_ * F_.transpose() + Q_;                                                  // extrapolate state covariance
+    }
+
+    void DynamicKalmanFilter::correct(const dVector &measurement_vector)
+    {
+        // Original formulation: K = P*H.T*(H*P*H.T + R)^-1
+        // Equivalent to: K.T = linalg.solve((HPH.T+R).T, HP.T)
+
+        // Compute Kalman Gain using p.s.d. LDLT solver of Eigen library
+        const dMatrix K{((H_ * P_ * H_.transpose() + R_).transpose()).ldlt().solve(H_ * P_.transpose()).transpose()};
+
+        // Update the state estimate
+        x_hat_ += K * (measurement_vector - H_ * x_hat_); // Update state estimate using measurement
+        P_ -= K * H_ * P_;                                // Update covariance estimate using measurement
+    }
+
+}
+
+#endif // DYNAMIC_KALMAN_FILTER_H

--- a/sailtrack/kalman-c/fixed-kalman-filter.h
+++ b/sailtrack/kalman-c/fixed-kalman-filter.h
@@ -1,0 +1,144 @@
+/* TODO
+ *        
+ *       - Do some Testing 
+ * 
+ *	     - Check numerical stability of implementation (P staying p.s.d. for prolonged amount of time)
+ *	      -- if unstable, change algorithm to more stable one (e.g. square root formulation)
+ *
+ *       Possible optimization routes:
+ *         - Use model specific simplifications (R being diagonal)
+ *         - specify model at compile-time, i.e. fully templetize or constexpr everything  
+ *         - study the Eigen library documentation at https://eigen.tuxfamily.org/dox/
+ *             -- e. g. passing matrices as arguments: https://eigen.tuxfamily.org/dox/TopicFunctionTakingEigenTypes.html
+ *                 --- pass arguments with Eigen::Ref?? (no temporaries but losing alignment information)
+ */
+
+#ifndef FIXED_KALMAN_FILTER_H
+#define FIXED_KALMAN_FILTER_H
+
+// YOU NEED TO ADD YOUR EIGEN LIBRARY PATH YOURSELF
+#include <Eigen/Dense> // TODO - Make this library work in PlatformIO
+
+namespace kf
+{
+
+  // Useful Aliases
+  // TODO - Test float vs double on target platform
+  template <size_t ROW, size_t COL>
+  using fMatrix = Eigen::Matrix<double, ROW, COL>;
+
+  template <size_t ROW>
+  using fVector = Eigen::Matrix<double, ROW, 1>;
+
+  /** Generic implementation of a Kalman Filter using Eigen library.
+   *  Matrices have fixed size, determined by template parameters.
+   * 
+   *  Preliminary test shows that for the metis vela 6D model the fixed
+   *  sized Kalman filter is apprx. twice as fast as the dynamically
+   *  sized one.
+   *
+   *  N - state dim, M - input dim, P - output dim
+   */
+  template <size_t DIM_N, size_t DIM_M, size_t DIM_P> // N - state dim, M - input dim, P - output dim
+  class FixedKalmanFilter
+  {
+  public:
+    FixedKalmanFilter(const fMatrix<DIM_N, DIM_N> &F, const fMatrix<DIM_N, DIM_M> &G, const fMatrix<DIM_P, DIM_N> &H,
+                      const fMatrix<DIM_N, DIM_N> &Q);
+    FixedKalmanFilter(const fMatrix<DIM_N, DIM_N> &F, const fMatrix<DIM_N, DIM_M> &G, const fMatrix<DIM_P, DIM_N> &H,
+                      const fMatrix<DIM_N, DIM_N> &Q, const fVector<DIM_N> &x_hat_init, const fMatrix<DIM_N, DIM_N> &P_init);
+
+    // Time Update
+    void predict();
+    void predict(const fVector<DIM_M> &input_vector);
+    void predict(const fVector<DIM_M> &input_vector, const fVector<DIM_P> &measurement_vector);
+
+    // Measurement Update
+    void correct(const fVector<DIM_P> &measurement_vector);
+
+    // Member access
+    const fVector<DIM_N> &state_estimate() const { return x_hat_; }
+    const fMatrix<DIM_N, DIM_N> &state_covariance_estimate() const { return P_; }
+
+    // Member update
+    void update_noise_covariance(const fMatrix<DIM_P, DIM_P> &R_new) { R_ = R_new; }
+
+  private:
+    // TODO - Change to const where appropriate, eventually constexpr for fixed model if necessary
+    const fMatrix<DIM_N, DIM_N> F_; // state transition
+    const fMatrix<DIM_N, DIM_M> G_; // input/control
+    const fMatrix<DIM_P, DIM_N> H_; // output/observation
+    const fMatrix<DIM_N, DIM_N> Q_; // state noise covariance
+    fMatrix<DIM_P, DIM_P> R_;       // measurment noise covariance
+    fMatrix<DIM_N, DIM_P> S_;       // measure-to-state uncorrelation (?)
+    fVector<DIM_N> x_hat_;          // state estimate
+    fMatrix<DIM_N, DIM_N> P_;       // state covariance estimate
+  };
+
+  template <size_t DIM_N, size_t DIM_M, size_t DIM_P>
+  FixedKalmanFilter<DIM_N, DIM_M, DIM_P>::FixedKalmanFilter(const fMatrix<DIM_N, DIM_N> &F, const fMatrix<DIM_N, DIM_M> &G, const fMatrix<DIM_P, DIM_N> &H,
+                                                            const fMatrix<DIM_N, DIM_N> &Q)
+      : F_{F},
+        G_{G},
+        H_{H},
+        Q_{Q},
+        R_{fMatrix<DIM_P, DIM_P>::Zero()},
+        S_{fMatrix<DIM_N, DIM_P>::Zero()},
+        x_hat_{fVector<DIM_N>::Zero()},
+        P_{fMatrix<DIM_N, DIM_N>::Identity()}
+  {
+  }
+
+  template <size_t DIM_N, size_t DIM_M, size_t DIM_P>
+  FixedKalmanFilter<DIM_N, DIM_M, DIM_P>::FixedKalmanFilter(const fMatrix<DIM_N, DIM_N> &F, const fMatrix<DIM_N, DIM_M> &G, const fMatrix<DIM_P, DIM_N> &H,
+                                                            const fMatrix<DIM_N, DIM_N> &Q, const fVector<DIM_N> &x_hat_init, const fMatrix<DIM_N, DIM_N> &P_init)
+      : F_{F},
+        G_{G},
+        H_{H},
+        Q_{Q},
+        R_{fMatrix<DIM_P, DIM_P>::Zero()},
+        S_{fMatrix<DIM_N, DIM_P>::Zero()},
+        x_hat_{x_hat_init},
+        P_{P_init}
+  {
+  }
+
+  template <size_t DIM_N, size_t DIM_M, size_t DIM_P>
+  void FixedKalmanFilter<DIM_N, DIM_M, DIM_P>::predict()
+  {
+    x_hat_ = F_ * x_hat_;               // extrapolate state
+    P_ = F_ * P_ * F_.transpose() + Q_; // extrapolate state covariance
+  }
+
+  template <size_t DIM_N, size_t DIM_M, size_t DIM_P>
+  void FixedKalmanFilter<DIM_N, DIM_M, DIM_P>::predict(const fVector<DIM_M> &input_vector)
+  {
+    x_hat_ = F_ * x_hat_ + G_ * input_vector; // extrapolate state
+    P_ = F_ * P_ * F_.transpose() + Q_;       // extrapolate state covariance
+  }
+
+  template <size_t DIM_N, size_t DIM_M, size_t DIM_P>
+  void FixedKalmanFilter<DIM_N, DIM_M, DIM_P>::predict(const fVector<DIM_M> &input_vector, const fVector<DIM_P> &measurement_vector)
+  {
+    // NOTE - R is diagonal in our model, can be optimized.
+    x_hat_ = F_ * x_hat_ + G_ * input_vector + S_ * R_.ldlt().solve(measurement_vector); // extrapolate state
+    P_ = F_ * P_ * F_.transpose() + Q_;                                                  // extrapolate state covariance
+  }
+
+  template <size_t DIM_N, size_t DIM_M, size_t DIM_P>
+  void FixedKalmanFilter<DIM_N, DIM_M, DIM_P>::correct(const fVector<DIM_P> &measurement_vector)
+  {
+    // Original formulation: K = P*H.T*(H*P*H.T + R)^-1
+    // Equivalent to: K.T = linalg.solve((HPH.T+R).T, HP.T)
+
+    // Compute Kalman Gain using p.s.d. LDLT solver of Eigen library
+    const fMatrix<DIM_N, DIM_P> K{((H_ * P_ * H_.transpose() + R_).transpose()).ldlt().solve(H_ * P_.transpose()).transpose()};
+
+    // Update the state estimate
+    x_hat_ += K * (measurement_vector - H_ * x_hat_); // Update state estimate using measurement
+    P_ -= K * H_ * P_;                                // Update covariance estimate using measurement  //TODO - Check wether P stays p.s.d. over many function calls
+  }
+
+}
+
+#endif // FIXED_KALMAN_FILTER_H

--- a/sailtrack/kalman-c/test-script.cpp
+++ b/sailtrack/kalman-c/test-script.cpp
@@ -1,0 +1,100 @@
+#include <iostream>
+#include <chrono>
+#include <ctime>
+#include "fixed-kalman-filter.h"
+#include "dynamic-kalman-filter.h"
+
+
+using namespace kf;
+
+static constexpr float sample_time{0.1};
+static constexpr float w_std{0.1};
+
+
+int main() {
+
+    // Define (fixed) Model
+    fMatrix<6, 6> fF;
+    fF << 1, 0, 0, sample_time, 0, 0, 
+         0, 1, 0, 0, sample_time, 0,
+         0, 0, 1, 0, 0, sample_time,
+         0, 0, 0, 1, 0, 0,
+         0, 0, 0, 0, 1, 0,
+         0, 0, 0, 0, 0, 1;
+    
+    fMatrix<6, 3> fG;
+    fG << (sample_time*sample_time)/2, 0, 0,
+         0, (sample_time*sample_time)/2, 0,
+         0, 0, (sample_time*sample_time)/2,
+         sample_time, 0, 0,
+         0, sample_time, 0,
+         0, 0, sample_time;
+    
+    fMatrix<6, 6> fH{ fMatrix<6,6>::Identity() };
+
+    fMatrix<6, 6> fQ;
+    fQ = fG * fG.transpose() * (w_std*w_std);
+
+    fMatrix<6,6> fP_init;
+    fP_init = fQ;
+
+    fVector<6> fx_init{fVector<6>::Zero()};
+    
+    fMatrix<6, 6> fR{0.1 * fMatrix<6,6>::Identity()};
+
+    // Define (dynamic) Model
+    dMatrix dF = fF.eval();
+    dMatrix dG = fG.eval();
+    dMatrix dH = fH.eval();
+    dMatrix dQ = fQ.eval();
+    dMatrix dR = fR.eval();
+    dMatrix dP_init = fP_init.eval();
+    dVector dx_init = fx_init.eval();
+
+
+    // Initialize Filters
+    FixedKalmanFilter<6, 3, 6> fFilter(fF, fG, fH, fQ, fx_init, fP_init);
+    // DynamicKalmanFilter dFilter(dF, dG, dH, dQ, dx_init, dP_init);
+
+    // Create dummy input and measurment vectors
+    fVector<3> finput_vector;
+    // dVector dinput_vector;
+    finput_vector << 1, 1, 1;
+    // dinput_vector = finput_vector.eval();
+
+    fVector<6> fmeasurement_vector;
+    dVector dmeasurement_vector;
+    fmeasurement_vector << 1, 1, 1, 1, 1, 1;
+    dmeasurement_vector = fmeasurement_vector.eval();
+
+    // Run and time test computation
+    std::chrono::time_point<std::chrono::high_resolution_clock> start, end;
+
+    start = std::chrono::high_resolution_clock::now();
+    
+    /* On my machine, using -O2 -march=native -DNDEBUG to compile ,
+       the following code with the fixed size kalman filter was ~100 times
+       faster than the equivalent python code. 
+       More than 50 times faster when loop limit is set to 1.*/
+    for (size_t i = 0; i < 10000; i++) {
+        fFilter.update_noise_covariance(fR);
+        fFilter.predict(finput_vector);
+        fFilter.correct(fmeasurement_vector);
+
+        //dFilter.update_noise_covariance(fR);
+        //dFilter.predict(finput_vector);
+        //dFilter.correct(fmeasurement_vector);
+    }
+    end = std::chrono::high_resolution_clock::now();
+  
+    // Print the current state estimate and passed time
+    std::cout << fFilter.state_estimate() << std::endl;
+    std::cout << fFilter.state_covariance_estimate() << std::endl;
+    //std::cout << fFilter.state_estimate() << std::endl;
+    //std::cout << fFilter.state_covariance_estimate() << std::endl;
+
+
+    std::cout << std::chrono::duration_cast<std::chrono::microseconds>(end-start).count() << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
The filter is implemented as a class using the Eigen linear algebra library. At the moment two versions are implemented, one using dynamic sized matrices, the other fixed size.
Example usage can be found in the test-script.cpp file. To run it you need to have the Eigen header file in your path.