### PR TITLE
Fix `Automation_Custom_Script.sh`

### DIFF
--- a/Automation_Custom_Script.sh
+++ b/Automation_Custom_Script.sh
@@ -61,7 +61,7 @@ G_CONFIG_INJECT "omit_hostname =" "  omit_hostname = true" /etc/telegraf/telegra
 # Create the "SailTrack" organization (required by Grafana)
 G_EXEC curl --retry 10 --retry-delay 5 --retry-connrefused -s -X PUT -H "Content-Type: application/json" -d '{"name":"SailTrack"}' "http://admin:$global_password@localhost:3001/api/org"
 # Install the third-party custom track map panel
-G_EXEC grafana-cli --pluginUrl=https://github.com/alexandrainst/alexandra-trackmap-panel/archive/master.zip plugins install alexandra-trackmap-panel
+G_EXEC /usr/share/grafana/bin/grafana cli --pluginUrl=https://github.com/alexandrainst/alexandra-trackmap-panel/archive/master.zip plugins install alexandra-trackmap-panel
 # Allow the third-party plugin
 G_CONFIG_INJECT ";allow_loading_unsigned_plugins =" "allow_loading_unsigned_plugins = alexandra-trackmap-panel" /etc/grafana/grafana.ini
 # Enable the insertion of SVG files in Grafana panels (needed by the SailTrack logo in the home dashboard)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Follow the instructions below to get the SailTrack Core OS correctly installed. 
    2. Dismiss the `DietPi first run setup is currently running on another screen` message by hitting <kbd>Ctrl</kbd> + <kbd>C</kbd>.
    3. Check the logs coming from the installation progress with the following command:
       ```
-      tail -f /var/tmp/dietpi/logs/dietpi-firstrun-setup.log
+      tail -f /var/tmp/dietpi/logs/*.log
       ```
 9. Wait until the `SailTrack-CoreNet` Wi-Fi network is visible, meaning that the installation process has been successfully completed.
 


### PR DESCRIPTION
Quick fix of the broken `Automation_Custom_Script.sh` due to grafana/grafana#66967.

Moreover, I improved the log monitoring experience for the first run setup. In particular, during the first run setup the logs are stored in multiple `.log` files. Jumping between those files with `tail -f` is cumbersome and slow. Fortunately, `tail` gives the possibility to specify multiple files (even using glob patterns) and it will monitor all of them all at once.

The fix has been tested on a Raspberry Pi 4 and the first run setup completes successfully.

@Magform it should be a very quick review 😉