### PR TITLE
Migration to paho 2.0

### DIFF
--- a/sailtrack/sailtrack-processor
+++ b/sailtrack/sailtrack-processor
@@ -10,7 +10,7 @@ import sys
 from collections import deque
 from datetime import timedelta
 
-from paho.mqtt.client import Client
+from paho.mqtt.client import Client, CallbackAPIVersion
 from timeloop import Timeloop
 
 # -------------------------- Configuration -------------------------- #
@@ -70,7 +70,7 @@ def on_message_callback_imu(client, userdata, message):
     buffer["roll"].append(imu["euler"]["x"])
 
 
-mqtt = Client(MQTT_CLIENT_ID)
+mqtt = Client(CallbackAPIVersion.VERSION1, MQTT_CLIENT_ID)
 mqtt.username_pw_set("mosquitto", os.environ["SAILTRACK_GLOBAL_PASSWORD"])
 mqtt.message_callback_add("sensor/gps0", on_message_callback_gps)
 mqtt.message_callback_add("sensor/imu0", on_message_callback_imu)

--- a/sailtrack/sailtrack-status
+++ b/sailtrack/sailtrack-status
@@ -11,7 +11,7 @@ import sys
 from datetime import timedelta
 
 from gpiozero import DigitalInputDevice, CPUTemperature, LoadAverage, DiskUsage
-from paho.mqtt.client import Client
+from paho.mqtt.client import Client, CallbackAPIVersion
 from smbus2 import SMBus
 from timeloop import Timeloop
 
@@ -54,7 +54,7 @@ def get_battery_capacity():
     return regval / 256
 
 
-mqtt = Client(MQTT_CLIENT_ID)
+mqtt = Client(CallbackAPIVersion.VERSION1, MQTT_CLIENT_ID)
 mqtt.username_pw_set("mosquitto", os.environ["SAILTRACK_GLOBAL_PASSWORD"])
 mqtt.on_publish = on_publish_callback
 mqtt.connect("localhost")

--- a/sailtrack/sailtrack-timesync
+++ b/sailtrack/sailtrack-timesync
@@ -12,7 +12,7 @@ import os
 import time
 from datetime import timedelta
 
-from paho.mqtt.client import Client
+from paho.mqtt.client import Client, CallbackAPIVersion
 from timeloop import Timeloop
 
 # -------------------------- Configuration -------------------------- #
@@ -44,7 +44,7 @@ def on_message_callback(client, userdata, message):
             time_syncs += 1
 
 
-mqtt = Client(MQTT_CLIENT_ID)
+mqtt = Client(CallbackAPIVersion.VERSION1, MQTT_CLIENT_ID)
 mqtt.username_pw_set("mosquitto", os.environ["SAILTRACK_GLOBAL_PASSWORD"])
 mqtt.on_message = on_message_callback
 mqtt.connect("localhost")


### PR DESCRIPTION
Updated sailtrack processes to accommodate compatibility with Paho MQTT library version 2.0.0.
However, it's worth noting that the function we are currently using has been deprecated in this version and will be removed in version 3.
