### PR TITLE
Adjusted Service Startup Sequence

### DIFF
--- a/rootfs/etc/systemd/system/sailtrack-processor.service
+++ b/rootfs/etc/systemd/system/sailtrack-processor.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=SailTrack-Processor
+After=mosquitto.service
 
 [Service]
 EnvironmentFile=-/etc/default/sailtrack

--- a/rootfs/etc/systemd/system/sailtrack-status.service
+++ b/rootfs/etc/systemd/system/sailtrack-status.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=SailTrack-Status
+After=mosquitto.service
 
 [Service]
 EnvironmentFile=-/etc/default/sailtrack

--- a/rootfs/etc/systemd/system/sailtrack-timesync.service
+++ b/rootfs/etc/systemd/system/sailtrack-timesync.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=SailTrack-TimeSync
+After=mosquitto.service
 
 [Service]
 EnvironmentFile=-/etc/default/sailtrack


### PR DESCRIPTION
Fix for issue #30 
The services now start after the MQTT broker service `mosquitto`, preventing connection errors.